### PR TITLE
Formalize singleton injection of non-singletons

### DIFF
--- a/container/src/main/java/io/smallrye/beanbag/BeanBag.java
+++ b/container/src/main/java/io/smallrye/beanbag/BeanBag.java
@@ -16,8 +16,8 @@ import io.smallrye.common.constraint.Assert;
  */
 public final class BeanBag {
 
-    private final List<BeanDefinition<?>> beanDefinitions;
     private final Scope singletonScope;
+    private final ScopeDefinition scopeDefinition;
 
     BeanBag(Builder builder) {
         final List<BeanDefinition<?>> definitions = new ArrayList<>();
@@ -30,8 +30,10 @@ public final class BeanBag {
                 definitions.add(definition);
             }
         }
-        singletonScope = Scope.of(null, singletonBeans);
-        beanDefinitions = List.copyOf(definitions);
+        // create a copy of the non-singleton scope so singletons can inject from there
+        final ScopeDefinition scopeDefinition = new ScopeDefinition(List.copyOf(definitions));
+        singletonScope = new Scope(null, scopeDefinition, new ScopeDefinition(singletonBeans));
+        this.scopeDefinition = scopeDefinition;
     }
 
     private <T> BeanDefinition<T> makeDefinition(final BeanBuilder<T> beanBuilder) {
@@ -51,7 +53,7 @@ public final class BeanBag {
      * @return the new resolution scope (not {@code null})
      */
     public Scope newScope() {
-        return Scope.of(singletonScope, beanDefinitions);
+        return new Scope(singletonScope, null, scopeDefinition);
     }
 
     /**

--- a/container/src/main/java/io/smallrye/beanbag/ScopeDefinition.java
+++ b/container/src/main/java/io/smallrye/beanbag/ScopeDefinition.java
@@ -1,0 +1,18 @@
+package io.smallrye.beanbag;
+
+import java.util.List;
+
+/**
+ * A definition for a scope.
+ */
+final class ScopeDefinition {
+    private final List<BeanDefinition<?>> definitions;
+
+    ScopeDefinition(final List<BeanDefinition<?>> definitions) {
+        this.definitions = definitions;
+    }
+
+    List<BeanDefinition<?>> getBeanDefinitions() {
+        return definitions;
+    }
+}


### PR DESCRIPTION
Singletons will have a one-off scope created which they can inject from. When resolving beans, the one-off scope is not visible, so singletons will always get their own instance of the things they inject.