### PR TITLE
Load Sisu metadata and beans in parallel

### DIFF
--- a/container/src/main/java/io/smallrye/beanbag/BeanBag.java
+++ b/container/src/main/java/io/smallrye/beanbag/BeanBag.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import io.smallrye.common.constraint.Assert;
 
@@ -146,7 +147,10 @@ public final class BeanBag {
          */
         private List<String> includePackages = List.of();
 
-        private final List<BeanBuilder<?>> beanBuilders = new ArrayList<>();
+        /**
+         * Bean builders may be added concurrently
+         */
+        private final Collection<BeanBuilder<?>> beanBuilders = new ConcurrentLinkedDeque<>();
 
         Builder() {
         }

--- a/sisu/src/main/java/io/smallrye/beanbag/sisu/BeanLoadingTask.java
+++ b/sisu/src/main/java/io/smallrye/beanbag/sisu/BeanLoadingTask.java
@@ -1,0 +1,10 @@
+package io.smallrye.beanbag.sisu;
+
+import java.io.IOException;
+
+/**
+ * Bean loading related task
+ */
+interface BeanLoadingTask {
+    void run() throws IOException;
+}

--- a/sisu/src/main/java/io/smallrye/beanbag/sisu/BeanLoadingTaskRunner.java
+++ b/sisu/src/main/java/io/smallrye/beanbag/sisu/BeanLoadingTaskRunner.java
@@ -1,0 +1,58 @@
+package io.smallrye.beanbag.sisu;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Phaser;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Task runner that runs {@link BeanLoadingTask}s asynchronously and in parallel
+ */
+class BeanLoadingTaskRunner {
+
+    private static final Logger log = Logger.getLogger(BeanLoadingTaskRunner.class);
+
+    private final Phaser phaser = new Phaser(1);
+    /**
+     * Errors caught while running tasks
+     */
+    private final Collection<Exception> errors = new ConcurrentLinkedDeque<>();
+
+    /**
+     * Runs a bean loading task asynchronously. This method may return before the task has completed.
+     *
+     * @param task task to run
+     */
+    void run(BeanLoadingTask task) {
+        phaser.register();
+        CompletableFuture.runAsync(() -> {
+            try {
+                task.run();
+            } catch (Exception e) {
+                errors.add(e);
+            } finally {
+                phaser.arriveAndDeregister();
+            }
+        });
+    }
+
+    /**
+     * Blocks until all the tasks have completed.
+     * <p>
+     * In case some tasks failed with errors, this method will log each error and throw a {@link RuntimeException}
+     * with a corresponding message.
+     */
+    void waitForCompletion() {
+        phaser.arriveAndAwaitAdvance();
+        if (!errors.isEmpty()) {
+            log.error("The following errors where caught while loading beans:");
+            int i = 0;
+            for (var e : errors) {
+                log.error(++i + ") " + e.getMessage(), e);
+            }
+            throw new RuntimeException("Failed to load beans, please see the errors logged above");
+        }
+    }
+}


### PR DESCRIPTION
This change makes `Sisu` class load metadata and create beans in parallel.

With this change, during Quarkus application bootstrap for a test run, `MavenFactory` gets initialized in ~45 ms instead of ~115 ms.