### PR TITLE
Use the default XMLInputFactory instance

### DIFF
--- a/sisu/src/main/java/io/smallrye/beanbag/sisu/Sisu.java
+++ b/sisu/src/main/java/io/smallrye/beanbag/sisu/Sisu.java
@@ -120,7 +120,7 @@ public final class Sisu {
         try (InputStream is = conn.getInputStream()) {
             try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8)) {
                 try (BufferedReader br = new BufferedReader(isr)) {
-                    XMLStreamReader xr = XMLInputFactory.newInstance().createXMLStreamReader(br);
+                    XMLStreamReader xr = XMLInputFactory.newDefaultFactory().createXMLStreamReader(br);
                     try (XMLCloser ignored = xr::close) {
                         while (xr.hasNext()) {
                             if (xr.next() == XMLStreamReader.START_ELEMENT) {


### PR DESCRIPTION
This is part of my work to reduce the consequences of CL leaks in Quarkus.

I think this is the right thing to do... but while it fixes some issues I have in Quarkus... it makes the tests here fail loudly:

```
[ERROR] io.smallrye.beanbag.maven.MavenFactoryTestCase.testAllTestBeansDiscovered -- Time elapsed: 0.004 s <<< ERROR!
io.smallrye.beanbag.NoSuchBeanException: No matching bean available: type is class io.smallrye.beanbag.maven.beans.Vigna
	at io.smallrye.beanbag.Scope.getBean(Scope.java:259)
	at io.smallrye.beanbag.Scope.requireBean(Scope.java:164)
	at io.smallrye.beanbag.BeanBag.requireBean(BeanBag.java:85)
	at io.smallrye.beanbag.maven.MavenFactoryTestCase.testAllTestBeansDiscovered(MavenFactoryTestCase.java:86)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

I tried to pass a few different CLs to the tests but it didn't fix anything.

@dmlloyd any chance you could have a look, I know you love class loaders :)