### PR TITLE
Upgrade to Maven 4

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -123,7 +123,7 @@
 
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-http</artifactId>
+            <artifactId>maven-resolver-transport-jetty</artifactId>
         </dependency>
 
         <dependency>

--- a/maven/src/main/java/io/smallrye/beanbag/maven/MavenFactory.java
+++ b/maven/src/main/java/io/smallrye/beanbag/maven/MavenFactory.java
@@ -24,6 +24,7 @@ import org.apache.maven.settings.building.SettingsBuildingException;
 import org.apache.maven.settings.building.SettingsBuildingRequest;
 import org.apache.maven.settings.building.SettingsBuildingResult;
 import org.apache.maven.settings.building.SettingsProblem;
+import org.codehaus.plexus.components.secdispatcher.SecDispatcher;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -35,7 +36,6 @@ import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.eclipse.aether.util.repository.DefaultMirrorSelector;
 import org.eclipse.aether.util.repository.DefaultProxySelector;
-import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 
 import io.smallrye.beanbag.BeanBag;
 import io.smallrye.beanbag.BeanInstantiationException;
@@ -287,7 +287,8 @@ public final class MavenFactory {
         }
         DefaultMirrorSelector mirrorSelector = new DefaultMirrorSelector();
         for (Mirror mirror : settings.getMirrors()) {
-            mirrorSelector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false, mirror.getMirrorOf(),
+            mirrorSelector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false, mirror.isBlocked(),
+                    mirror.getMirrorOf(),
                     mirror.getMirrorOfLayouts());
         }
         Set<RemoteRepository> mirroredRepos = new LinkedHashSet<RemoteRepository>();

--- a/maven/src/test/java/io/smallrye/beanbag/maven/MavenFactoryTestCase.java
+++ b/maven/src/test/java/io/smallrye/beanbag/maven/MavenFactoryTestCase.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
+
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsBuildingException;
 import org.apache.maven.settings.building.SettingsProblem;
@@ -12,10 +14,10 @@ import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.http.HttpWagon;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.components.secdispatcher.SecDispatcher;
+import org.codehaus.plexus.components.secdispatcher.SecDispatcherException;
 import org.eclipse.aether.RepositorySystem;
 import org.junit.jupiter.api.Test;
-import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
-import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
 import io.smallrye.beanbag.maven.beans.Phaseolus;
 import io.smallrye.beanbag.maven.beans.Pisum;
@@ -46,7 +48,7 @@ public final class MavenFactoryTestCase {
     }
 
     @Test
-    public void testNamedSecDispatcherProvider() throws SecDispatcherException {
+    public void testNamedSecDispatcherProvider() throws SecDispatcherException, IOException {
         final MavenFactory mavenFactory = MavenFactory.create(MavenFactory.class.getClassLoader());
         SecDispatcher sd = mavenFactory.getContainer().requireBean(SecDispatcher.class, "maven");
         assertEquals("hello", sd.decrypt("hello"));

--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,19 @@
         <version.io.smallrye.common>2.10.0</version.io.smallrye.common>
         <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
 
-        <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
+        <version.org.eclipse.sisu>0.9.0.M3</version.org.eclipse.sisu>
         <version.javax.inject>1</version.javax.inject>
 
-        <version.maven>3.9.9</version.maven>
+        <version.maven>4.0.0-rc-3-SNAPSHOT</version.maven>
         <version.maven.filtering>3.3.0</version.maven.filtering>
         <version.maven.plugin-annotations>3.7.1</version.maven.plugin-annotations>
         <version.maven.project>2.2.1</version.maven.project>
-        <version.maven.resolver>1.9.22</version.maven.resolver>
+        <version.maven.resolver>2.0.5</version.maven.resolver>
         <version.maven.wagon>3.5.3</version.maven.wagon>
         <version.plexus.interpolation>1.27</version.plexus.interpolation>
         <version.plexus.utils>4.0.2</version.plexus.utils>
-        <version.plexus.sec-dispatcher>2.0</version.plexus.sec-dispatcher>
-        <version.plexus.cipher>2.1.0</version.plexus.cipher>
+        <version.plexus.sec-dispatcher>4.1.0</version.plexus.sec-dispatcher>
+        <version.plexus.cipher>3.0.0</version.plexus.cipher>
 
         <version.commons.codec>1.18.0</version.commons.codec>
         <version.commons.lang3>3.17.0</version.commons.lang3>
@@ -260,7 +260,7 @@
 
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-transport-http</artifactId>
+                <artifactId>maven-resolver-transport-jetty</artifactId>
                 <version>${version.maven.resolver}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <version.org.eclipse.sisu>0.9.0.M3</version.org.eclipse.sisu>
         <version.javax.inject>1</version.javax.inject>
 
-        <version.maven>4.0.0-rc-3-SNAPSHOT</version.maven>
+        <version.maven>4.0.0-rc-3</version.maven>
         <version.maven.filtering>3.3.0</version.maven.filtering>
         <version.maven.plugin-annotations>3.7.1</version.maven.plugin-annotations>
         <version.maven.project>2.2.1</version.maven.project>


### PR DESCRIPTION
The still refers to the maven-resolver-provider which is deprecated in Maven 4, but provides compatibility with Maven 3 world.
